### PR TITLE
Scoop support

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -12,37 +12,54 @@ jobs:
         runs-on: windows-latest
         steps:
             - uses: actions/checkout@v3
+              
             - uses: actions-rs/toolchain@v1
               with:
                   toolchain: stable
+            - uses: actions/setup-python@v5
+              with:
+                python-version: '3.10'
+
             - uses: Swatinem/rust-cache@v2
             - uses: actions-rs/cargo@v1
               with:
                   command: build
                   args: --release --all-features
-            - run: |
+
+            - name: Creating scoop manifest
+              working-directory: ./release
+              run: python make_scoop_manifest.py > tmaze.json
+            - name: Get version and rename file to version specific
+              run: |
                   $tmversion = ./target/release/tmaze.exe --version | Select-String -Pattern '^tmaze ([0-9]+\.[0-9]+\.[0-9]+)$' | %{$_.Matches[0].Groups[1].Value}
                   $filepath = "./target/release/tmaze-${tmversion}-win-x86_64.exe"
                   echo "BIN_FILEPATH=$filepath" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
                   echo "TM_VERSION=$tmversion" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
                   mv ./target/release/tmaze.exe ${filepath}
             - run: echo "$Env:GITHUB_CONTEXT"
+
             - uses: actions/upload-artifact@v3
               with:
-                  path: ${{env.BIN_FILEPATH}}
+                  path: |
+                      ${{env.BIN_FILEPATH}}
+                      ./release/tmaze.json
                   name: release
+
     build-linux-x64:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+
             - uses: actions-rs/toolchain@v1
               with:
                   toolchain: stable
             - uses: Swatinem/rust-cache@v2
+
             - uses: actions-rs/cargo@v1
               with:
                   command: build
                   args: --release --all-features
+
             - run: strip ./target/release/tmaze
             - run: ls -l ./target/release/
             - run: |
@@ -57,12 +74,14 @@ jobs:
                   else
                       echo "FAIL"
                   fi
+
             - uses: actions/upload-artifact@v3
               with:
                   path: |
                       ${{env.BIN_FILEPATH}}
                       ./target/release/version
                   name: release
+
     draft-release:
         needs: ["build-win-x64", "build-linux-x64"]
         runs-on: ubuntu-latest
@@ -71,12 +90,15 @@ jobs:
               with:
                   path: release-files/
                   name: release
+
             - run: find ./release-files/ -type f -name "linux" -exec chmod +x ./release-files/{} \;
             - run: ls ./release-files/
-            - run: |
+            - name: Save version to env
+              run: |
                   version=$(<./release-files/version)
-                  rm ./release-files/version
                   echo "TM_VERSION=$version" >> $GITHUB_ENV
+            - name: Remove version file
+              run: rm ./release-files/version
             - uses: ncipollo/release-action@v1
               with:
                   artifacts: "./release-files/*"
@@ -86,6 +108,7 @@ jobs:
                   skipIfReleaseExists: true
                   draft: true
                   tag: ${{ env.TM_VERSION }}
+
     publish-on-crates:
         runs-on: ubuntu-latest
         steps:
@@ -93,14 +116,14 @@ jobs:
             - uses: actions-rs/toolchain@v1
               with:
                   toolchain: stable
-                  
+
             - name: publish cmaze
               uses: katyo/publish-crates@v2
               with:
                 path: ./cmaze
                 registry-token: ${{ secrets.CRATES_IO }}
                 ignore-unpublished-changes: true
-                
+
             - name: publish tmaze
               uses: katyo/publish-crates@v2
               with:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -3,6 +3,7 @@ name: Build and Release
 on:
     push:
         branches: ["master"]
+    workflow_dispatch:
 
 env:
     CARGO_TERM_COLOR: always
@@ -121,13 +122,14 @@ jobs:
             - name: publish cmaze
               uses: katyo/publish-crates@v2
               with:
-                path: ./cmaze
-                registry-token: ${{ secrets.CRATES_IO }}
-                ignore-unpublished-changes: true
+                  path: ./cmaze
+                  registry-token: ${{ secrets.CRATES_IO }}
+                  ignore-unpublished-changes: true
 
             - name: publish tmaze
               uses: katyo/publish-crates@v2
               with:
-                path: ./tmaze
-                registry-token: ${{ secrets.CRATES_IO }}
-                ignore-unpublished-changes: true
+                  path: ./tmaze
+                  registry-token: ${{ secrets.CRATES_IO }}
+                  ignore-unpublished-changes: true
+

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -106,6 +106,7 @@ jobs:
                   commit: master
                   generateReleaseNotes: true
                   skipIfReleaseExists: true
+                  allowUpdates: true
                   draft: true
                   tag: ${{ env.TM_VERSION }}
 

--- a/release/make_scoop_manifest.py
+++ b/release/make_scoop_manifest.py
@@ -1,0 +1,42 @@
+#!/bin/python3
+from subprocess import run as run_process
+from json import loads, dumps
+from pprint import pprint
+from hashlib import sha256
+from urllib import request
+
+metadata = loads(
+    run_process(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"], capture_output=True
+    ).stdout.decode("utf-8")
+)
+
+tmaze_metadata = metadata["packages"][0]
+
+version = tmaze_metadata["version"]
+desc = tmaze_metadata["description"]
+
+tmaze_url = "https://github.com/ur-fault/tmaze"
+
+release_assets = f"{tmaze_url}/releases/download/{version}"
+
+download_url = f"{release_assets}/tmaze-{version}-win-x86_64.exe#/tmaze.exe"
+scoop_manifest = f"{release_assets}/tmaze.json"
+
+manifest = {
+    "version": version,
+    "architecture": {
+        "64bit": {
+            "url": download_url,
+        },
+        "checkver": {
+            "url": "{scoop_manifest}",
+            "jsonpath": "$.version",
+        },
+        "autoupdate": {},
+    },
+    "description": desc,
+    "homepage": tmaze_url,
+}
+
+print(dumps(manifest, indent=4))


### PR DESCRIPTION
Add scoop support

Script for automatic generation of scoop manifest with version and autoupdate. And generate the manifest on Github Action workflow run.