### PR TITLE
Add better panic messages using better-panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "better-panic"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa9e1d11a268684cbd90ed36370d7577afb6c62d912ddff5c15fc34343e5036"
+dependencies = [
+ "backtrace",
+ "console",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +460,18 @@ dependencies = [
  "mp3lame-encoder",
  "walkdir",
  "wav",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -710,6 +732,12 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2246,6 +2274,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tmaze"
 version = "1.14.4"
 dependencies = [
+ "better-panic",
  "chrono",
  "clap",
  "cmaze",

--- a/tmaze/Cargo.toml
+++ b/tmaze/Cargo.toml
@@ -36,6 +36,7 @@ crates_io_api = { version = "0.11.0", optional = true, default-features = false,
 semver = { version = "1.0.17", optional = true }
 tokio = { version = "1.27.0", optional = true, features = ["rt", "rt-multi-thread"] }
 rodio = { version = "0.18.1", optional = true, default-features = false, features = ["wav", "mp3"] }
+better-panic = "0.3.0"
 
 [build-dependencies]
 flacenc = "0.3.1"

--- a/tmaze/src/main.rs
+++ b/tmaze/src/main.rs
@@ -43,6 +43,8 @@ fn main() -> Result<(), GameError> {
         return Ok(());
     }
 
+    better_panic::install();
+
     let mut app = App::empty();
     let menu = MainMenu::new(&app.data().settings);
     app.activities_mut()


### PR DESCRIPTION
When TMaze crashes, it will print much easier to read error message, it's colorful and make more sense than the default Rust one. It's using [better-panic](https://crates.io/crates/better-panic) by [mitsuhiko](https://github.com/mitsuhiko).