### PR TITLE
Better logging and read-only mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Session.vim
 tmaze/themes
 tmaze/**/*.ron
+log.txt

--- a/tmaze/examples/audio.rs
+++ b/tmaze/examples/audio.rs
@@ -8,7 +8,7 @@ use tmaze::{
 
 #[cfg(feature = "sound")]
 fn main() {
-    logging::get_logger().switch_debug();
+    logging::get_logger(log::Level::Info);
 
     let mut app = App::empty();
 

--- a/tmaze/examples/audio.rs
+++ b/tmaze/examples/audio.rs
@@ -7,7 +7,7 @@ use tmaze::{
 
 #[cfg(feature = "sound")]
 fn main() {
-    let mut app = App::empty();
+    let mut app = App::empty(true);
 
     let menu_config = menu::MenuConfig::new(
         "Audio settings",

--- a/tmaze/examples/audio.rs
+++ b/tmaze/examples/audio.rs
@@ -1,15 +1,12 @@
 #[cfg(feature = "sound")]
 use tmaze::{
     app::app::{App, AppData},
-    logging,
     sound::track,
     ui::{menu, MenuItem, OptionDef, SliderDef},
 };
 
 #[cfg(feature = "sound")]
 fn main() {
-    logging::get_logger(log::Level::Info);
-
     let mut app = App::empty();
 
     let menu_config = menu::MenuConfig::new(

--- a/tmaze/examples/box.rs
+++ b/tmaze/examples/box.rs
@@ -12,7 +12,7 @@ use tmaze::{
 use crossterm::event::{Event as TermEvent, KeyEvent};
 
 fn main() {
-    let mut app = App::new(Activity::new("example", "box", Box::new(MyActivity)));
+    let mut app = App::new(Activity::new("example", "box", Box::new(MyActivity)), true);
 
     log::info!("Starting app");
 

--- a/tmaze/examples/empty_menu.rs
+++ b/tmaze/examples/empty_menu.rs
@@ -7,13 +7,16 @@ use tmaze::{
 };
 
 fn main() {
-    let mut app = App::new(Activity::new_base_boxed(
-        "activity",
-        MyActivity(
-            false,
-            Popup::new("Press any key to quit".to_string(), vec![]),
+    let mut app = App::new(
+        Activity::new_base_boxed(
+            "activity",
+            MyActivity(
+                false,
+                Popup::new("Press any key to quit".to_string(), vec![]),
+            ),
         ),
-    ));
+        true,
+    );
 
     app.run();
 }

--- a/tmaze/examples/logging.rs
+++ b/tmaze/examples/logging.rs
@@ -11,7 +11,7 @@ use tmaze::{
 use crossterm::event::{Event as TermEvent, KeyEvent};
 
 fn main() {
-    let mut app = App::new(Activity::new("example", "box", Box::new(MyActivity)));
+    let mut app = App::new(Activity::new("example", "box", Box::new(MyActivity)), true);
 
     log::info!("Starting app");
 

--- a/tmaze/examples/menu.rs
+++ b/tmaze/examples/menu.rs
@@ -13,7 +13,7 @@ fn main() {
     .default(1);
 
     let menu = menu::Menu::new(menu_config).into_activity();
-    let mut app = App::new(menu);
+    let mut app = App::new(menu, true);
 
     app.run();
 }

--- a/tmaze/examples/one_menu.rs
+++ b/tmaze/examples/one_menu.rs
@@ -7,13 +7,16 @@ use tmaze::{
 };
 
 fn main() {
-    let mut app = App::new(Activity::new_base_boxed(
-        "activity",
-        MyActivity(
-            false,
-            Popup::new("Press any key to quit".to_string(), vec![]),
+    let mut app = App::new(
+        Activity::new_base_boxed(
+            "activity",
+            MyActivity(
+                false,
+                Popup::new("Press any key to quit".to_string(), vec![]),
+            ),
         ),
-    ));
+        true,
+    );
 
     app.run();
 }

--- a/tmaze/examples/popup.rs
+++ b/tmaze/examples/popup.rs
@@ -7,17 +7,20 @@ use tmaze::{
 };
 
 fn main() -> io::Result<()> {
-    let mut app = App::new(Activity::new_base_boxed(
-        "popup",
-        popup::Popup::new(
-            "Title".to_string(),
-            vec![
-                "Line 1".to_string(),
-                "Line 2".to_string(),
-                "Line 3".to_string(),
-            ],
+    let mut app = App::new(
+        Activity::new_base_boxed(
+            "popup",
+            popup::Popup::new(
+                "Title".to_string(),
+                vec![
+                    "Line 1".to_string(),
+                    "Line 2".to_string(),
+                    "Line 3".to_string(),
+                ],
+            ),
         ),
-    ));
+        true,
+    );
 
     let res = app.run();
 

--- a/tmaze/examples/updates.rs
+++ b/tmaze/examples/updates.rs
@@ -8,16 +8,19 @@ use tmaze::{
 
 #[cfg(feature = "updates")]
 fn main() {
-    let mut app = App::new(Activity::new_base_boxed(
-        "activity",
-        MyActivity(Popup::new(
-            "Checking for updates in the background".to_string(),
-            vec![
-                "Please wait...".to_string(),
-                "Result will be shown in the notification area".to_string(),
-            ],
-        )),
-    ));
+    let mut app = App::new(
+        Activity::new_base_boxed(
+            "activity",
+            MyActivity(Popup::new(
+                "Checking for updates in the background".to_string(),
+                vec![
+                    "Please wait...".to_string(),
+                    "Result will be shown in the notification area".to_string(),
+                ],
+            )),
+        ),
+        true,
+    );
 
     app.run();
 }

--- a/tmaze/src/app/app.rs
+++ b/tmaze/src/app/app.rs
@@ -133,8 +133,6 @@ impl App {
         };
         logger.init();
 
-        log::warn!("Read-only mode: {}", on_off(read_only, false));
-
         #[cfg(feature = "sound")]
         let sound_player = SoundPlayer::new(settings.clone());
 

--- a/tmaze/src/app/app.rs
+++ b/tmaze/src/app/app.rs
@@ -122,7 +122,7 @@ impl App {
         let theme_def = settings.get_theme();
         let theme = resolver.resolve(&theme_def);
 
-        logging::init();
+        logging::init(settings.get_logging_level());
 
         #[cfg(feature = "sound")]
         let sound_player = SoundPlayer::new(settings.clone());
@@ -224,7 +224,11 @@ impl App {
                 .draw(self.renderer.frame(), &self.data.theme)
                 .unwrap();
 
-            logging::get_logger().draw(Dims(0, 0), self.renderer.frame(), &self.data.theme);
+            logging::get_logger(self.data.settings.get_logging_level()).draw(
+                Dims(0, 0),
+                self.renderer.frame(),
+                &self.data.theme,
+            );
 
             // TODO: let activities show debug info and about the app itself
             // then we can draw it here
@@ -242,7 +246,7 @@ impl App {
 
     fn switch_debug(&mut self) {
         self.data.use_data.show_debug = !self.data.use_data.show_debug;
-        get_logger().switch_debug();
+        get_logger(self.data.settings.get_logging_level()).switch_debug(&self.data.settings);
         log::warn!(
             "Debug mode: {}",
             on_off(self.data.use_data.show_debug, false)

--- a/tmaze/src/app/jobs.rs
+++ b/tmaze/src/app/jobs.rs
@@ -65,4 +65,8 @@ impl Job {
     pub fn call(self, data: &mut AppData) {
         (self.task)(data);
     }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
 }

--- a/tmaze/src/data/mod.rs
+++ b/tmaze/src/data/mod.rs
@@ -70,7 +70,9 @@ impl SaveData {
     fn write_to(&self, path: &Path) -> Result<(), ron::Error> {
         to_writer(File::create(path)?, self)
     }
+}
 
+impl SaveData {
     pub fn update_last_check(&mut self) -> Result<(), ron::Error> {
         self.last_update_check = Some(Local::now());
         self.write()

--- a/tmaze/src/helpers/constants.rs
+++ b/tmaze/src/helpers/constants.rs
@@ -52,4 +52,8 @@ pub mod paths {
     pub fn save_data_path() -> PathBuf {
         base_path().join("data.ron")
     }
+
+    pub fn log_file_path() -> PathBuf {
+        base_path().join("log.txt")
+    }
 }

--- a/tmaze/src/logging.rs
+++ b/tmaze/src/logging.rs
@@ -252,7 +252,7 @@ impl Log for AppLogger {
             level: record.level(),
             pushed: std::time::Instant::now(),
             message: record.args().to_string(),
-            source: record.module_path().unwrap_or("unknown").to_string(),
+            source: record.target().to_string(),
         });
 
         if let Some(file) = &self.file {
@@ -265,7 +265,7 @@ impl Log for AppLogger {
                     "[{}][{}][{}] {}",
                     record.level(),
                     timestamp,
-                    record.module_path().unwrap_or("unknown"),
+                    record.target(),
                     record.args()
                 ) {
                     log::error!("Failed to write to log file: {}", err);

--- a/tmaze/src/main.rs
+++ b/tmaze/src/main.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(version, author, about, name = "tmaze")]
 struct Args {
-    #[clap(short, long, action, help = "Reset config to default and quit")]
+    #[clap(long, action, help = "Reset config to default and quit")]
     reset_config: bool,
     #[clap(short, long, action, help = "Show config path and quit")]
     show_config_path: bool,
@@ -20,6 +20,13 @@ struct Args {
     debug_config: bool,
     #[clap(short, long, action, help = "Delete all saved data and quit")]
     delete_data: bool,
+    #[clap(
+        short,
+        long,
+        action,
+        help = "Run in read-only mode, no data will be saved"
+    )]
+    read_only: bool,
 }
 
 fn main() -> Result<(), GameError> {
@@ -41,7 +48,7 @@ fn main() -> Result<(), GameError> {
     }
 
     if _args.debug_config {
-        println!("{:#?}", Settings::load(settings_path()));
+        println!("{:#?}", Settings::load(settings_path(), true));
         return Ok(());
     }
 
@@ -52,7 +59,7 @@ fn main() -> Result<(), GameError> {
 
     better_panic::install();
 
-    let mut app = App::empty();
+    let mut app = App::empty(_args.read_only);
     let menu = MainMenu::new();
     app.activities_mut()
         .push(Activity::new_base_boxed("main menu", menu));

--- a/tmaze/src/settings/default_settings.ron
+++ b/tmaze/src/settings/default_settings.ron
@@ -1,5 +1,5 @@
 Settings (
-    // theme of the game, if None, default theme will be used
+    // theme of the game, if None, default theme will be used.
     // default theme is automatically loaded from <game config>/themes/default_theme.json5,
     // which is generated when none is found.
     //
@@ -7,30 +7,20 @@ Settings (
     // from the <game config>/themes directory. It can be either .json[5] or .toml format.
     // theme: "theme.json",
 
-    // color scheme:
-    // - valid colors:
-    //  - black
-    //  - dark_grey
-    //  - red
-    //  - dark_red
-    //  - green
-    //  - dark_green
-    //  - yellow
-    //  - dark_yellow
-    //  - blue
-    //  - dark_blue
-    //  - magenta
-    //  - dark_magenta
-    //  - cyan
-    //  - dark_cyan
-    //  - white
-    //  - grey
-    color_scheme: ColorScheme (
-        normal: "dark_grey",
-        player: "red",
-        goal: "yellow",
-        text: "grey",
-    ),
+    // logging levels for different logging mechanisms in the game.
+    // - valid levels:
+    //  - trace
+    //  - debug
+    //  - info
+    //  - warn
+    //  - error
+    // 
+    // messages in the UI
+    logging_level: "info",
+    // messages in the UI if debug mode is enabled
+    debug_logging_level: "debug",
+    // messages in the log file
+    file_logging_level: "info",
 
     // player will move only one space at the time,
     // otherwise it will move until other possible move

--- a/tmaze/src/settings/mod.rs
+++ b/tmaze/src/settings/mod.rs
@@ -89,6 +89,10 @@ pub struct SettingsInner {
     // general
     #[serde(default)]
     pub theme: Option<String>,
+    #[serde(default)]
+    pub logging_level: Option<String>,
+    #[serde(default)]
+    pub debug_logging_level: Option<String>,
 
     // viewport
     #[serde(default)]
@@ -191,6 +195,22 @@ impl Settings {
         } else {
             ThemeDefinition::load_default_or_save().expect("could not load default theme")
         }
+    }
+
+    pub fn get_logging_level(&self) -> log::Level {
+        self.read()
+            .logging_level
+            .clone()
+            .and_then(|level| level.parse().ok())
+            .unwrap_or(log::Level::Info)
+    }
+
+    pub fn get_debug_logging_level(&self) -> log::Level {
+        self.read()
+            .debug_logging_level
+            .clone()
+            .and_then(|level| level.parse().ok())
+            .unwrap_or(log::Level::Info)
     }
 
     pub fn get_slow(&self) -> bool {

--- a/tmaze/src/settings/mod.rs
+++ b/tmaze/src/settings/mod.rs
@@ -93,6 +93,8 @@ pub struct SettingsInner {
     pub logging_level: Option<String>,
     #[serde(default)]
     pub debug_logging_level: Option<String>,
+    #[serde(default)]
+    pub file_logging_level: Option<String>,
 
     // viewport
     #[serde(default)]
@@ -208,6 +210,14 @@ impl Settings {
     pub fn get_debug_logging_level(&self) -> log::Level {
         self.read()
             .debug_logging_level
+            .clone()
+            .and_then(|level| level.parse().ok())
+            .unwrap_or(log::Level::Info)
+    }
+
+    pub fn get_file_logging_level(&self) -> log::Level {
+        self.read()
+            .file_logging_level
             .clone()
             .and_then(|level| level.parse().ok())
             .unwrap_or(log::Level::Info)

--- a/tmaze/src/settings/mod.rs
+++ b/tmaze/src/settings/mod.rs
@@ -200,9 +200,9 @@ impl Settings {
     pub fn get_theme(&self) -> ThemeDefinition {
         let theme_name = self.read().theme.clone();
         if let Some(theme_name) = theme_name {
-            ThemeDefinition::load_by_name(&theme_name).expect("could not load theme")
+            ThemeDefinition::load_by_name(&theme_name).expect("could not load the theme")
         } else {
-            ThemeDefinition::load_default(self.read_only).expect("could not load default theme")
+            ThemeDefinition::load_default(self.read_only).expect("could not load the default theme")
         }
     }
 

--- a/tmaze/src/settings/theme.rs
+++ b/tmaze/src/settings/theme.rs
@@ -56,15 +56,19 @@ const DEFAULT_THEME_NAME: &str = default_theme_name!();
 const DEFAULT_THEME: &str = include_str!(concat!("./", default_theme_name!()));
 
 impl ThemeDefinition {
-    pub fn load_default_or_save() -> Result<Self, LoadError> {
+    pub fn load_default(read_only: bool) -> Result<Self, LoadError> {
         let path = theme_file_path(DEFAULT_THEME_NAME);
 
-        std::fs::create_dir_all(path.parent().unwrap())?;
-        if !path.exists() {
-            std::fs::write(&path, DEFAULT_THEME)?;
-        }
+        if !read_only {
+            std::fs::create_dir_all(path.parent().unwrap())?;
+            if !path.exists() {
+                std::fs::write(&path, DEFAULT_THEME)?;
+            }
 
-        Self::load_by_path(path)
+            Self::load_by_path(path)
+        } else {
+            Ok(json5::from_str(DEFAULT_THEME)?)
+        }
     }
 
     pub fn load_by_name(path: &str) -> Result<Self, LoadError> {

--- a/tmaze/src/updates.rs
+++ b/tmaze/src/updates.rs
@@ -54,17 +54,21 @@ pub fn check(app_data: &mut AppData) {
             Ok(Some(version)) => {
                 log::warn!("Newer version found: {}", version);
                 qer.queue(Job::new(|data| {
-                    data.save
-                        .update_last_check()
-                        .expect("Failed to save the save data");
+                    if !data.settings.is_ro() {
+                        data.save
+                            .update_last_check()
+                            .expect("Failed to save the save data");
+                    }
                 }));
             }
             Ok(None) => {
                 log::info!("No newer version found");
                 qer.queue(Job::new(|data| {
-                    data.save
-                        .update_last_check()
-                        .expect("Failed to save the save data");
+                    if !data.settings.is_ro() {
+                        data.save
+                            .update_last_check()
+                            .expect("Failed to save the save data");
+                    }
                 }));
             }
             Err(err) if display_update_errors => {


### PR DESCRIPTION
- Logging to the file
- Set logging levels in the settings
- Better design of the `AppLogger`
- Run TMaze in read-only mode, meaning no data will be written to the disk, (default settings, default theme, save data)