### PR TITLE
Fix `EdgeFollow`

### DIFF
--- a/cmaze/src/dims.rs
+++ b/cmaze/src/dims.rs
@@ -274,6 +274,7 @@ impl From<DimsU> for (usize, usize) {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum Offset {
     Abs(i32),
     Rel(f32),

--- a/tmaze/src/app/game.rs
+++ b/tmaze/src/app/game.rs
@@ -929,7 +929,7 @@ impl Screen for GameActivity {
 
 #[inline]
 fn render_edge_follow_rulers(rulers: (Offset, Offset), frame: &mut Frame, vp: Rect, theme: &Theme) {
-    let [s_start, s_end] = theme.extract(["debug_rulers_start", "debug_rulers_end"]);
+    let [s_start, s_end] = theme.extract(["debug.rulers.start", "debug.rulers.end"]);
 
     let vps = vp.size();
 


### PR DESCRIPTION
- `Offset` not parsing correctly, it's not `serde(untagged)`
- When `EdgeFollow` is enabled, edge rulers crash the game, incorrect style name