### PR TITLE
Option for listing style options

### DIFF
--- a/tmaze/src/app/app.rs
+++ b/tmaze/src/app/app.rs
@@ -325,7 +325,7 @@ pub struct AppStateData {
     pub show_debug: bool,
 }
 
-fn init_theme_resolver() -> ThemeResolver {
+pub fn init_theme_resolver() -> ThemeResolver {
     let mut resolver = ThemeResolver::new();
 
     resolver

--- a/tmaze/src/main.rs
+++ b/tmaze/src/main.rs
@@ -1,9 +1,7 @@
-use std::collections::BTreeMap;
-
 use tmaze::{
     app::{app::init_theme_resolver, game::MainMenu, Activity, App, GameError},
     helpers::constants::paths::{save_data_path, settings_path},
-    settings::Settings,
+    settings::{theme::StyleNode, Settings},
 };
 
 #[cfg(feature = "updates")]
@@ -115,39 +113,7 @@ fn print_style_options(mode: StylesPrintMode, counted: bool) {
         }
         StylesPrintMode::Deps => todo!(),
         StylesPrintMode::Logical => {
-            #[derive(Debug)]
-            struct Node<'a>(BTreeMap<&'a str, Node<'a>>);
-
-            impl<'a> Node<'a> {
-                fn new() -> Self {
-                    Self(BTreeMap::new())
-                }
-
-                fn add(&mut self, rem_segs: &[&'a str]) {
-                    if rem_segs.is_empty() {
-                        return;
-                    }
-                    let seg = rem_segs[0];
-                    let node = self.0.entry(seg).or_insert_with(Node::new);
-                    if rem_segs.len() > 1 {
-                        node.add(&rem_segs[1..]);
-                    }
-                }
-
-                fn print(&self, depth: usize, show_no: bool, no: &mut usize) {
-                    for (key, node) in &self.0 {
-                        if show_no {
-                            println!("{no:<depth$}{key}", depth = depth);
-                        } else {
-                            println!("{:<depth$}{key}", ' ', depth = depth);
-                        }
-                        node.print(depth + TREE_INDENT, show_no, no);
-                        *no += 1;
-                    }
-                }
-            }
-
-            let mut node = Node::new();
+            let mut node = StyleNode::new();
             let theme_resolver = init_theme_resolver().to_map();
             for style in theme_resolver.keys() {
                 let segs = style.split('.').collect::<Vec<_>>();
@@ -155,9 +121,9 @@ fn print_style_options(mode: StylesPrintMode, counted: bool) {
             }
             let node_count = theme_resolver.len();
             if counted {
-                node.print(node_count.to_string().len() + 1, true, &mut 1);
+                node.print(TREE_INDENT, node_count.to_string().len() + 1, true, &mut 1);
             } else {
-                node.print(0, false, &mut 1);
+                node.print(TREE_INDENT, 0, false, &mut 1);
             }
         }
     }

--- a/tmaze/src/main.rs
+++ b/tmaze/src/main.rs
@@ -1,7 +1,7 @@
 use tmaze::{
     app::{app::init_theme_resolver, game::MainMenu, Activity, App, GameError},
     helpers::constants::paths::{save_data_path, settings_path},
-    settings::{theme::StyleNode, Settings},
+    settings::Settings,
 };
 
 #[cfg(feature = "updates")]
@@ -103,27 +103,31 @@ fn print_style_options(mode: StylesPrintMode, counted: bool) {
     const TREE_INDENT: usize = 4;
 
     match mode {
-        StylesPrintMode::List => {
-            let theme_resolver = init_theme_resolver().to_map();
-            let mut styles = theme_resolver.keys().collect::<Vec<_>>();
-            styles.sort();
-            for style in styles {
-                println!("{}", style);
-            }
-        }
-        StylesPrintMode::Deps => todo!(),
         StylesPrintMode::Logical => {
-            let mut node = StyleNode::new();
-            let theme_resolver = init_theme_resolver().to_map();
-            for style in theme_resolver.keys() {
-                let segs = style.split('.').collect::<Vec<_>>();
-                node.add(&segs);
-            }
-            let node_count = theme_resolver.len();
+            let theme_resolver = init_theme_resolver();
+            let node = theme_resolver.to_logical_tree();
+            let node_count = theme_resolver.as_map().len();
             if counted {
                 node.print(TREE_INDENT, node_count.to_string().len() + 1, true, &mut 1);
             } else {
                 node.print(TREE_INDENT, 0, false, &mut 1);
+            }
+        }
+        StylesPrintMode::Deps => {
+            let theme_resolver = init_theme_resolver();
+            let node = theme_resolver.to_deps_tree();
+            let node_count = theme_resolver.as_map().len();
+            if counted {
+                node.print(TREE_INDENT, node_count.to_string().len() + 1, true, &mut 1);
+            } else {
+                node.print(TREE_INDENT, 0, false, &mut 1);
+            }
+        }
+        StylesPrintMode::List => { let theme_resolver = init_theme_resolver().to_map();
+            let mut styles = theme_resolver.keys().collect::<Vec<_>>();
+            styles.sort();
+            for style in styles {
+                println!("{}", style);
             }
         }
     }

--- a/tmaze/src/settings/theme.rs
+++ b/tmaze/src/settings/theme.rs
@@ -303,7 +303,7 @@ pub enum NamedColor {
     Grey,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ThemeResolver(HashMap<String, String>);
 
 #[allow(dead_code)]
@@ -362,6 +362,10 @@ impl ThemeResolver {
     pub fn extend(&mut self, other: Self) -> &mut Self {
         self.0.extend(other.0);
         self
+    }
+
+    pub fn to_map(self) -> HashMap<String, String> {
+        self.0
     }
 }
 
@@ -461,7 +465,10 @@ mod tests {
     fn parse_color() {
         assert_eq!(json5::from_str(r##""#FF0000""##), Ok(Color::Hex(255, 0, 0)));
         assert_eq!(json5::from_str(r##""#F00""##), Ok(Color::Hex(255, 0, 0)));
-        assert_eq!(json5::from_str::<Color>(r##""#123""##), json5::from_str(r##""#112233""##));
+        assert_eq!(
+            json5::from_str::<Color>(r##""#123""##),
+            json5::from_str(r##""#112233""##)
+        );
         assert!(json5::from_str::<Color>(r###""##23""###).is_err());
         assert!(json5::from_str::<Color>(r###""123""###).is_err());
         assert!(json5::from_str::<Color>(r###""#12""###).is_err());


### PR DESCRIPTION
New `--print-styles[=logical/list/deps]` option, that prints style hierarchy in different ways.

- logical - prints them based on names (split by `.`), similar to namespaces,
- list - just print all of the available options,
- deps - print them as a inheritance tree, what inherits from what.

It's commad line flag/option, it outputs into stdout and then quits.